### PR TITLE
Adding support for dynamic colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,9 @@ If the document has no `lang` set and the `lang` option is not provided, it will
 
 ## Customization
 
-| CSS selector           | Details                                                                                                                                                                                        |
-| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `.hljs-copy-wrapper`   | Applied to the parent `<pre>` element that wraps the .hljs code.                                                                                                                               |
-| `.hljs-copy-button`    | The copy button itself.<br /><br />The variable `--hljs-theme-background` is automatically applied to the parent element. This allows the button to inherit the code block's background color. |
-| `[data-copied='true']` | This data attribute is applied to the copy button and is set to `true` for two seconds when the copy action is performed.                                                                      |
-| `.hljs-copy-alert`     | A visually hidden status element that announces the copy confirmation to screen readers.                                                                                                       |
+| CSS selector           | Details                                                                                                                                                                                                                             |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `.hljs-copy-wrapper`   | Applied to the parent `<pre>` element that wraps the .hljs code.                                                                                                                                                                    |
+| `.hljs-copy-button`    | The copy button itself.<br /><br />The variables `--hljs-theme-background` and `--hljs-theme-color` are automatically applied to the parent element. This allows the button to inherit the code block's text and background colors. |
+| `[data-copied='true']` | This data attribute is applied to the copy button and is set to `true` for two seconds when the copy action is performed.                                                                                                           |
+| `.hljs-copy-alert`     | A visually hidden status element that announces the copy confirmation to screen readers.                                                                                                                                            |

--- a/index.js
+++ b/index.js
@@ -35,6 +35,10 @@ class CopyButtonPlugin {
       "--hljs-theme-background",
       window.getComputedStyle(el).backgroundColor
     );
+    el.parentElement.style.setProperty(
+      "--hljs-theme-color",
+      window.getComputedStyle(el).color
+    );
 
     button.onclick = function () {
       if (!navigator.clipboard) return;

--- a/styles/highlightjs-copy.css
+++ b/styles/highlightjs-copy.css
@@ -9,31 +9,46 @@
 .hljs-copy-button {
   position: absolute;
   transform: translateX(calc(100% + 1.125em));
-  top: 1em;
-  right: 1em;
+  top: 13px;
+  right: 13px;
   width: 2rem;
   height: 2rem;
   text-indent: -9999px; /* Hide the inner text */
-  color: #fff;
+  color: var(--hljs-theme-color);
   border-radius: 0.25rem;
-  border: 1px solid #ffffff22;
-  background-color: #2d2b57;
+  border: 1px solid;
+  border-color: color-mix(in srgb, var(--hljs-theme-color), transparent 80%);
   background-color: var(--hljs-theme-background);
-  background-image: url('data:image/svg+xml;utf-8,<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M6 5C5.73478 5 5.48043 5.10536 5.29289 5.29289C5.10536 5.48043 5 5.73478 5 6V20C5 20.2652 5.10536 20.5196 5.29289 20.7071C5.48043 20.8946 5.73478 21 6 21H18C18.2652 21 18.5196 20.8946 18.7071 20.7071C18.8946 20.5196 19 20.2652 19 20V6C19 5.73478 18.8946 5.48043 18.7071 5.29289C18.5196 5.10536 18.2652 5 18 5H16C15.4477 5 15 4.55228 15 4C15 3.44772 15.4477 3 16 3H18C18.7956 3 19.5587 3.31607 20.1213 3.87868C20.6839 4.44129 21 5.20435 21 6V20C21 20.7957 20.6839 21.5587 20.1213 22.1213C19.5587 22.6839 18.7957 23 18 23H6C5.20435 23 4.44129 22.6839 3.87868 22.1213C3.31607 21.5587 3 20.7957 3 20V6C3 5.20435 3.31607 4.44129 3.87868 3.87868C4.44129 3.31607 5.20435 3 6 3H8C8.55228 3 9 3.44772 9 4C9 4.55228 8.55228 5 8 5H6Z" fill="white"/><path fill-rule="evenodd" clip-rule="evenodd" d="M7 3C7 1.89543 7.89543 1 9 1H15C16.1046 1 17 1.89543 17 3V5C17 6.10457 16.1046 7 15 7H9C7.89543 7 7 6.10457 7 5V3ZM15 3H9V5H15V3Z" fill="white"/></svg>');
-  background-repeat: no-repeat;
-  background-position: center;
   transition: background-color 200ms ease, transform 200ms ease-out;
+  overflow: hidden;
 }
+.hljs-copy-button:not([data-copied="true"])::before {
+  content: "";
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  background-color: currentColor;
+  mask: url('data:image/svg+xml;utf-8,<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M6 5C5.73478 5 5.48043 5.10536 5.29289 5.29289C5.10536 5.48043 5 5.73478 5 6V20C5 20.2652 5.10536 20.5196 5.29289 20.7071C5.48043 20.8946 5.73478 21 6 21H18C18.2652 21 18.5196 20.8946 18.7071 20.7071C18.8946 20.5196 19 20.2652 19 20V6C19 5.73478 18.8946 5.48043 18.7071 5.29289C18.5196 5.10536 18.2652 5 18 5H16C15.4477 5 15 4.55228 15 4C15 3.44772 15.4477 3 16 3H18C18.7956 3 19.5587 3.31607 20.1213 3.87868C20.6839 4.44129 21 5.20435 21 6V20C21 20.7957 20.6839 21.5587 20.1213 22.1213C19.5587 22.6839 18.7957 23 18 23H6C5.20435 23 4.44129 22.6839 3.87868 22.1213C3.31607 21.5587 3 20.7957 3 20V6C3 5.20435 3.31607 4.44129 3.87868 3.87868C4.44129 3.31607 5.20435 3 6 3H8C8.55228 3 9 3.44772 9 4C9 4.55228 8.55228 5 8 5H6Z" fill="black"/><path fill-rule="evenodd" clip-rule="evenodd" d="M7 3C7 1.89543 7.89543 1 9 1H15C16.1046 1 17 1.89543 17 3V5C17 6.10457 16.1046 7 15 7H9C7.89543 7 7 6.10457 7 5V3ZM15 3H9V5H15V3Z" fill="black"/></svg>');
+  mask-repeat: no-repeat;
+  mask-size: 1rem 1rem;
+  mask-position: center center;
+}
+
 .hljs-copy-button:hover {
-  border-color: #ffffff44;
+  background-color: color-mix(
+    in srgb,
+    var(--hljs-theme-color),
+    transparent 90%
+  );
 }
 .hljs-copy-button:active {
-  border-color: #ffffff66;
+  border-color: color-mix(in srgb, var(--hljs-theme-color), transparent 60%);
 }
 .hljs-copy-button[data-copied="true"] {
   text-indent: 0px; /* Shows the inner text */
   width: auto;
-  background-image: none;
 }
 @media (prefers-reduced-motion) {
   .hljs-copy-button {

--- a/styles/highlightjs-copy.css
+++ b/styles/highlightjs-copy.css
@@ -9,8 +9,8 @@
 .hljs-copy-button {
   position: absolute;
   transform: translateX(calc(100% + 1.125em));
-  top: 13px;
-  right: 13px;
+  top: 0.5em;
+  right: 0.5em;
   width: 2rem;
   height: 2rem;
   text-indent: -9999px; /* Hide the inner text */
@@ -32,7 +32,7 @@
   background-color: currentColor;
   mask: url('data:image/svg+xml;utf-8,<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M6 5C5.73478 5 5.48043 5.10536 5.29289 5.29289C5.10536 5.48043 5 5.73478 5 6V20C5 20.2652 5.10536 20.5196 5.29289 20.7071C5.48043 20.8946 5.73478 21 6 21H18C18.2652 21 18.5196 20.8946 18.7071 20.7071C18.8946 20.5196 19 20.2652 19 20V6C19 5.73478 18.8946 5.48043 18.7071 5.29289C18.5196 5.10536 18.2652 5 18 5H16C15.4477 5 15 4.55228 15 4C15 3.44772 15.4477 3 16 3H18C18.7956 3 19.5587 3.31607 20.1213 3.87868C20.6839 4.44129 21 5.20435 21 6V20C21 20.7957 20.6839 21.5587 20.1213 22.1213C19.5587 22.6839 18.7957 23 18 23H6C5.20435 23 4.44129 22.6839 3.87868 22.1213C3.31607 21.5587 3 20.7957 3 20V6C3 5.20435 3.31607 4.44129 3.87868 3.87868C4.44129 3.31607 5.20435 3 6 3H8C8.55228 3 9 3.44772 9 4C9 4.55228 8.55228 5 8 5H6Z" fill="black"/><path fill-rule="evenodd" clip-rule="evenodd" d="M7 3C7 1.89543 7.89543 1 9 1H15C16.1046 1 17 1.89543 17 3V5C17 6.10457 16.1046 7 15 7H9C7.89543 7 7 6.10457 7 5V3ZM15 3H9V5H15V3Z" fill="black"/></svg>');
   mask-repeat: no-repeat;
-  mask-size: 1rem 1rem;
+  mask-size: 1rem;
   mask-position: center center;
 }
 


### PR DESCRIPTION
Resolves #17 

This update will make the copy button adapt to the highlightjs theme being applied. This is desirable over the solution proposed in #19 since it allows the copy button to adapt to the chosen theme without additional configuration. 

![image](https://github.com/arronhunt/highlightjs-copy/assets/298336/72879384-ae51-4b95-8973-9ccb1656b257)
