### PR TITLE
Add an option to always display the copy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ npm install highlightjs-copy
 hljs.addPlugin(new CopyButtonPlugin());
 ```
 
+### Autohide
+
+By default, the copy button is hidden until a user hovers the code block. Set this to `false` to have the copy button always visible.
+
+```javascript
+hljs.addPlugin(
+  new CopyButtonPlugin({
+    autohide: false, // Always show the copy button
+  })
+);
+```
+
 ### With a callback
 
 ```javascript

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /**
  *  @file highlight-copy.js
  *  @author Arron Hunt <arronjhunt@gmail.com>
- *  @copyright Copyright 2021. All rights reserved.
+ *  @copyright Copyright 2021-2023. All rights reserved.
  */
 
 /**
@@ -14,19 +14,26 @@ class CopyButtonPlugin {
    * @param {CopyCallback} [options.callback]
    * @param {Hook} [options.hook]
    * @param {String} [options.lang] Defaults to the document body's lang attribute and falls back to "en"
+   * @param {Boolean} [options.autohide=true] Automatically hides the copy button until a user hovers the code block. Defaults to False
    */
   constructor(options = {}) {
-    self.hook = options.hook;
-    self.callback = options.callback;
-    self.lang = options.lang || document.documentElement.lang || "en";
+    this.hook = options.hook;
+    this.callback = options.callback;
+    this.lang = options.lang || document.documentElement.lang || "en";
+    this.autohide =
+      typeof options.autohide !== "undefined" ? options.autohide : true;
   }
   "after:highlightElement"({ el, text }) {
+    let { hook, callback, lang, autohide } = this;
+
     // Create the copy button and append it to the codeblock.
     let button = Object.assign(document.createElement("button"), {
       innerHTML: locales[lang]?.[0] || "Copy",
       className: "hljs-copy-button",
     });
     button.dataset.copied = false;
+    button.dataset.autohide = autohide;
+
     el.parentElement.classList.add("hljs-copy-wrapper");
     el.parentElement.appendChild(button);
 

--- a/styles/highlightjs-copy.css
+++ b/styles/highlightjs-copy.css
@@ -2,13 +2,8 @@
   position: relative;
   overflow: hidden;
 }
-.hljs-copy-wrapper:hover .hljs-copy-button,
-.hljs-copy-button:focus {
-  transform: translateX(0);
-}
 .hljs-copy-button {
   position: absolute;
-  transform: translateX(calc(100% + 1.125em));
   top: 0.5em;
   right: 0.5em;
   width: 2rem;
@@ -50,6 +45,14 @@
   text-indent: 0px; /* Shows the inner text */
   width: auto;
 }
+.hljs-copy-button[data-autohide="true"] {
+  transform: translateX(calc(100% + 1.125em));
+}
+.hljs-copy-wrapper:hover .hljs-copy-button,
+.hljs-copy-button:focus {
+  transform: translateX(0);
+}
+
 @media (prefers-reduced-motion) {
   .hljs-copy-button {
     transition: none;


### PR DESCRIPTION
Disable the default behavior of autohiding by setting it to false. 

```javascript
hljs.addPlugin(
  new CopyButtonPlugin({
    autohide: false, // Always show the copy button
  })
);
```