### PR TITLE
Added nohljs-copy class to ignore some elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ hljs.addPlugin(
 );
 ```
 
+or add a class to your `<pre>` element,  `nohljs-copy`:
+
+```html
+<pre class="nohljs-copy">
+  <code>...</code>
+<pre>
+```
+
 ## Localization
 
 highlightjs-copy supports multiple locales by providing the correct language for accessibility.

--- a/index.js
+++ b/index.js
@@ -26,8 +26,9 @@ class CopyButtonPlugin {
     this.enabled = options.enabled;
   }
   "after:highlightElement"({ el, text }) {
-    // If the code block already has a copy button, return.
-    if (el.parentElement.querySelector(".hljs-copy-button")) return;
+    // If the code block already has a copy button, or its marked to ignore, return.
+    if (el.parentElement.querySelector(".hljs-copy-button")
+      || el.parentElement.classList.contains('nohljs-copy')) return;
 
     let { hook, callback, lang, autohide, enabled } = this;
 


### PR DESCRIPTION
This is to ignore some elements by adding a class `nohljs-copy` . Resolves and enhances #37 
This is inspired from [highlightjs-line-numbers](https://github.com/wcoder/highlightjs-line-numbers.js)