### PR TITLE
Prevent form submission on copy button click

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ class CopyButtonPlugin {
     let button = Object.assign(document.createElement("button"), {
       innerHTML: locales[lang]?.[0] || "Copy",
       className: "hljs-copy-button",
+      type: "button",
     });
     button.dataset.copied = false;
 


### PR DESCRIPTION
### The problem
If no type is specified and the button is rendered within a form, it will by default assume the type `submit`, causing the form to submit.

### The fix
Specify type `button` for the copy button.

### Ref
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button\#type