### PR TITLE
Add the type declaration file to use in TypeScript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,25 @@
+import type { HighlightResult } from "highlight.js"
+
+declare module "highlightjs-copy" {
+    declare interface CopyCallback {
+        (text: string, el: HTMLElement): undefined
+    }
+
+    declare interface Hook {
+        (text: string, el: HTMLElement): string | undefined
+    }
+
+
+    declare class CopyButtonPlugin {
+        constructor(options?: {
+            callback?: CopyCallback,
+            hook?: Hook,
+            lang?: String,
+            autohide?: Boolean
+        })
+
+        "after:highlightElement"(data: { el: Element, text: string }): void
+    }
+
+    export = CopyButtonPlugin
+}


### PR DESCRIPTION
I added the type declaration file for your library. Else, the IDEs as VSCode were saying this:
```plaintext
Could not find a declaration file for module 'highlightjs-copy'. 'c:/Users/me/path/to/project/node_modules/highlightjs-copy/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/highlightjs-copy` if it exists or add a new declaration (.d.ts) file containing `declare module 'highlightjs-copy';`
```
Now, all's right.